### PR TITLE
Remove redundant quotes from .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VUE_APP_API="http://localhost:1337"
+VUE_APP_API=http://localhost:1337


### PR DESCRIPTION
Quotes usage in .env files are redundant